### PR TITLE
Corrected bug in clearBit

### DIFF
--- a/src/Data/BitVector.hs
+++ b/src/Data/BitVector.hs
@@ -747,6 +747,9 @@ instance Bits BV where
 #endif
   bit i = BV (i+1) (2^i)
   {-# INLINE bit #-}
+  clearBit u@(BV n _) i = u .&. v
+    where v = bitVec n $ 2^n - 2^i - (1 :: Integer)
+  {-# INLINE clearBit #-}
   testBit (BV n a) i | i < n     = testBit a i
                      | otherwise = False
   {-# INLINE testBit #-}

--- a/test/Properties.hs
+++ b/test/Properties.hs
@@ -271,3 +271,13 @@ prop_group_join_id a = forallDivisorOf (size a) $ \n ->
 
 prop_show_read_id :: BV -> Bool
 prop_show_read_id a = read (show a) ==. a
+
+-- * clearBit
+
+prop_clear_bit :: BV -> Property
+prop_clear_bit a = forallIndexOf a $ \i ->
+                     let cb = clearBit a i
+                     in List.and
+                          [ cb @. i' == ((i /= i') && a @. i')
+                          | i' <- [0 .. size a ]
+                          ]


### PR DESCRIPTION
The default implementation of clearBit also clears
the bits to the left of the one passed as
parameter. The solution is to give an explicit
implementation.

Also, a quickCheck for clearBit has been added.